### PR TITLE
Show a Nostr account's name over a truncated npub

### DIFF
--- a/src/features/nostrlogin.js
+++ b/src/features/nostrlogin.js
@@ -9,7 +9,8 @@
 // published, because it means the nostr key can recover the money.
 
 import { newMnemonic } from '../wallet.js';
-import { npubOf, nsecOf } from '../nostr.js';
+import { npubOf, nsecOf, fetchNostrProfile } from '../nostr.js';
+import { shortAddr } from '../format.js';
 import { t } from '../i18n.js';
 import { qrSvg } from '../qr.js';
 import {
@@ -102,6 +103,36 @@ export function nostrLoginFeature(ctx) {
       toast(res.mode === 'derived' ? t('nlOpenedDerived') : t('nlOpenedRestored'));
       busy(false);
     } catch (e) { fail(e); }
+  }
+
+  // Kind-0 names for the accounts these cards have to name, asked for once per
+  // pubkey. Called from render, so the cache is what stops a repaint from
+  // queueing another lookup: the key is claimed before the fetch goes out, and
+  // a miss stays a miss rather than retrying against the relays on every frame.
+  const acctNames = new Map(); // pubkey hex → name, or null for asked-and-nothing
+  function acctName(pubkeyHex) {
+    if (!pubkeyHex) return null;
+    if (acctNames.has(pubkeyHex)) return acctNames.get(pubkeyHex);
+    acctNames.set(pubkeyHex, null);
+    fetchNostrProfile(pubkeyHex).then((p) => {
+      if (!p || !p.name) return;
+      acctNames.set(pubkeyHex, p.name);
+      render();
+    }).catch(() => {});
+    return null;
+  }
+
+  // Which account a card is about: the kind-0 name up front, the npub under it
+  // for the check no display name can settle. A bare npub is 63 unbreakable
+  // characters — the overflow this replaces — so it is always truncated, with
+  // the whole thing on the title for a hover or a copy.
+  function acctIdent(npub, name) {
+    const short = npub ? shortAddr(npub, 12, 8) : '';
+    // Nothing published: the npub is the only identifier, so it takes the pill.
+    if (!name) return npub ? h('div', { class: 'acct-pill mono', title: npub }, short) : null;
+    return h('div', { class: 'col', style: 'gap:5px' },
+      h('div', { class: 'acct-pill' }, name),
+      npub ? h('div', { class: 'acct-npub', title: npub }, short) : null);
   }
 
   async function createForSigner() {
@@ -237,7 +268,7 @@ export function nostrLoginFeature(ctx) {
     if (ui.nostrLoginNew) {
       return h('div', { class: 'card col', style: 'gap:10px' },
         h('h3', { style: 'margin:0' }, t('nlNewTitle')),
-        h('div', { class: 'small muted' }, ui.nostrLoginNew.npub || ''),
+        acctIdent(ui.nostrLoginNew.npub, acctName(ui.nostrLoginNew.signer.pubkey)),
         h('p', { class: 'small muted', style: 'margin:0' }, t('nlNewDesc')),
         h('div', { class: 'notice info small' }, t('nlBackupWarning')),
         ui.nostrLoginError ? h('div', { class: 'notice err' }, ui.nostrLoginError) : null,
@@ -359,7 +390,7 @@ export function nostrLoginFeature(ctx) {
         h('div', { class: 'row between' },
           h('h3', {}, t('nlLinkTitle')),
           h('span', { class: 'badge dot' + (live ? ' live' : ' off') }, live ? t('nlConnected') : t('nlDisconnected'))),
-        h('div', { class: 'small muted break' }, npubOf(st.pubkey) || st.pubkey),
+        acctIdent(npubOf(st.pubkey) || st.pubkey, acctName(st.pubkey)),
         h('p', { class: 'small faint', style: 'margin:0' }, t('nlLinkedDesc')),
         // Signing needs a live signer, and a reload always drops a remote one.
         // Without this the app can tell you it isn't connected and offer you
@@ -376,7 +407,7 @@ export function nostrLoginFeature(ctx) {
     const npub = wallet.nostrNpub && wallet.nostrNpub();
     return h('div', { class: 'card col' },
       h('h3', {}, t('nlLinkTitle')),
-      npub ? h('div', { class: 'small muted break' }, npub) : null,
+      acctIdent(npub, acctName(wallet.nostrPubkey && wallet.nostrPubkey())),
       h('p', { class: 'small muted', style: 'margin:0' }, t('nlBuiltinDesc')),
       exportSection(),
       linkSection());

--- a/src/style.css
+++ b/src/style.css
@@ -577,6 +577,22 @@ body::after {
 @keyframes mark-float { 50% { transform: translateY(-6px); } }
 @media (prefers-reduced-motion: reduce) { .onb-mark { animation: none; } }
 .onb-addr { color: var(--muted); font-family: var(--mono); font-size: 13px; }
+/* Which nostr account a sign-in step is about. A kind-0 name is arbitrary
+   user text and the npub fallback is long either way, so the pill clips with
+   an ellipsis instead of growing — the full npub stays in the title. */
+.acct-pill {
+  align-self: start; max-width: 100%; padding: 5px 12px; border-radius: 999px;
+  font-size: 14px; font-weight: 600; color: var(--ink);
+  background: var(--surface2); border: 1px solid var(--line);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.acct-pill.mono { font-family: var(--mono); font-weight: 500; }
+/* the npub under that name — secondary, and clipped on the same terms */
+.acct-npub {
+  max-width: 100%; padding-left: 2px; color: var(--faint);
+  font-family: var(--mono); font-size: 12px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
 /* balance card: one account at a time, dots to flip */
 .balance-face { min-height: 78px; }
 /* amount input with an inline Max affordance */


### PR DESCRIPTION
The sign-in confirm card printed a full 63-character npub with no wrapping, so it ran past the card edge. The settings card wrapped its npub only because it carried `.break`.

Both now lead with the account's kind-0 name and show a truncated npub beneath it. Full npub stays on the `title`.

## Changes

- `acctName(pubkeyHex)` — kind-0 lookup over the existing `fetchNostrProfile`, cached per pubkey. These fire from render, so the cache is what stops a repaint queueing another lookup: the key is claimed before the fetch goes out, and a miss stays a miss.
- `acctIdent(npub, name)` — the shared identity block. No name published, and the npub takes the pill itself.
- `.acct-pill` / `.acct-npub` — follows the existing pill idiom (`999px`, `--surface2`, `--line`). Clips with an ellipsis rather than wrapping, since a kind-0 name is arbitrary user text and would otherwise blow the card out again.

Applied at three sites: the create-wallet confirm card, the linked external account, and the wallet's built-in derived account. The third wasn't overflowing — it had `.break` — but it's the alternate branch of the same card and would have looked inconsistent left as bare text.

## Testing

`bun run build` passes. Not verified in a browser: the confirm card only renders for extension or bunker signers, since a pasted nsec always takes the `mode: 'derived'` path. The settings card is reachable with any normal wallet.