### PR TITLE
Carry lud16 in the NWC connection string

### DIFF
--- a/src/features/nwc.js
+++ b/src/features/nwc.js
@@ -92,9 +92,21 @@ export function nwcFeature(ctx) {
   const relays = () => NWC_RELAYS;
 
   // The string the user pastes into another app.
+  //
+  // lud16 is NIP-47's recommended way to hand the client a lightning address:
+  // an app with no lud16 on its profile can fill one in from the connection
+  // rather than asking. Only sent once a name is actually claimed — there is
+  // nothing to advertise before that.
+  //
+  // The `@` is left literal. It needs no escaping in a query value, and a
+  // client that reads the param without URL-decoding it would otherwise store
+  // a broken `name%40domain`; anything else stays encoded, so an exotic
+  // custom domain still can't inject a parameter.
   function uriFor(c) {
     const rs = relays().map((r) => `relay=${encodeURIComponent(r)}`).join('&');
-    return `nostr+walletconnect://${c.servicePk}?${rs}&secret=${c.secret}`;
+    const addr = hook('namesAddress');
+    const lud16 = addr ? `&lud16=${encodeURIComponent(addr).replace(/%40/g, '@')}` : '';
+    return `nostr+walletconnect://${c.servicePk}?${rs}&secret=${c.secret}${lud16}`;
   }
 
   function createConn({ name, maxSat, dailySat }) {


### PR DESCRIPTION
NIP-47 lists `lud16` as a recommended query param: "a lightning address that clients can use to automatically setup the `lud16` field on the user's profile if they have none configured." We weren't sending it, so a connecting app had to ask for an address we already know.

`uriFor` now appends `&lud16=<address>` when `hook('namesAddress')` returns one, and omits the param entirely before a name is claimed. The QR, the pasteable string, and the copy button all go through that one function.

## Encoding

The `@` is left literal; everything else is percent-encoded. `@` needs no escaping in a query value, and emitting `%40` would leave a client that reads the param without URL-decoding it storing a broken `name%40domain`. Encoding the rest means a custom domain carrying an `&` can't inject a parameter.

## Testing

`bun run build` passes. Query string round-tripped through `URLSearchParams`:

| `namesAddress()` | `lud16` read back | `secret` |
| --- | --- | --- |
| `null` | absent | intact |
| `satoshi@coinos.io` | `satoshi@coinos.io` | intact |
| `me@my.own.domain` | `me@my.own.domain` | intact |
| `x@evil.com&secret=deadbeef` | whole string, one value | intact |

Both a conformant parser and a naive `split('lud16=')` read the normal cases correctly. Not exercised against a live NWC client.